### PR TITLE
Fixed slashes in row keys

### DIFF
--- a/lib/hbase-row.js
+++ b/lib/hbase-row.js
@@ -12,11 +12,12 @@ var Row = function(client, table, key){
 Row.prototype.delete = function(){
 	var self = this
 	  , args = Array.prototype.slice.call(arguments)
-	  , key = '/'+this.table+'/'+this.key;
+	  , col = null;
 	if(typeof args[0] === 'string' || (typeof args[0] === 'object' && args[0] instanceof Array) ){
-		key += '/'+args.shift();
+		col = args.shift();
 	}
-	this.client.connection.delete(utils.url.encode(key), function( error, success ){
+	var url = utils.url.build([this.table, this.key], col);
+	this.client.connection.delete(url, function( error, success ){
 		args[0].apply(self, [error, error? null: true]);
 	},true);
 }
@@ -25,11 +26,12 @@ Row.prototype.delete = function(){
 Row.prototype.exists = function(column, callback){
 	var self = this
 	  , args = Array.prototype.slice.call(arguments)
-	  , key = '/'+this.table+'/'+this.key;
+	  , col = null;
 	if(typeof args[0] === 'string'){
-		key += '/'+args.shift();
+		col = args.shift();
 	}
-	this.client.connection.get(utils.url.encode(key), function( error, exists ){
+	var url = utils.url.build([this.table, this.key], col);
+	this.client.connection.get(url, function( error, exists ){
 		// note:
 		// if row does not exists: 404
 		// if row exists and column family does not exists: 503
@@ -47,28 +49,32 @@ Row.prototype.exists = function(column, callback){
 Row.prototype.get = function(column, callback){
 	var self = this
 	  , args = Array.prototype.slice.call(arguments)
-	  , key = '/'+this.table+'/'+this.key
 	  , isGlob = this.key.substr(-1,1)==='*'
-	  , options = {};
+	  , options = {}
+	  , path = [this.table, this.key]
+	  , cols = null
+	  , range = null
+	  , query = null;
 	if(typeof args[0] === 'string' || (typeof args[0] === 'object' && args[0] instanceof Array) ){
-		key += '/'+args.shift();
+		cols = args.shift();
 	}
 	if(typeof args[0] === 'object'){
 		options = args.shift();
 	}
 	if(options.start||options.end){
-		key += '/';
+		range = [null, null]
 		if(options.start){
-			key += options.start;
+			range[0] = options.start;
 		}
 		if(options.end){
-			key += ','+options.end;
+			range[1] = options.end;
 		}
 	}
 	if(options.v){
-		key += '?v='+options.v;
+		query = {v: options.v};
 	}
-	this.client.connection.get(utils.url.encode(key), function( error, data ){
+	var url = utils.url.build(path, cols, range, query);
+	this.client.connection.get(url, function( error, data ){
 		if(error) return args[0].apply(self, [error, null] );
 		var cells = [];
 		data.Row.forEach(function(row){
@@ -93,7 +99,8 @@ Row.prototype.get = function(column, callback){
 Row.prototype.put = function(columns, values, callback){
 	var self = this
 	  , args = Array.prototype.slice.call(arguments)
-	  , key = '/'+this.table+'/'+(this.key||'___false-row-key___')
+	  , path = [this.table, this.key||'___false-row-key___']
+	  , cols = null
 	  , body;
 	if(args.length>2){
 		var columns = args.shift()
@@ -115,7 +122,9 @@ Row.prototype.put = function(columns, values, callback){
 			key: utils.base64.encode(self.key),
 			Cell: []
 		};
+		cols = [];
 		columns.forEach(function(column,i){
+			cols.push(column);
 			var bodyCell = {};
 			if(timestamps){
 				bodyCell.timestamp = timestamps[i];
@@ -125,7 +134,6 @@ Row.prototype.put = function(columns, values, callback){
 			bodyRow.Cell.push(bodyCell);
 		})
 		body.Row.push(bodyRow);
-		key += '/'+columns;
 	}else{
 		var data = args.shift(),
 			callback = args.shift();
@@ -156,7 +164,8 @@ Row.prototype.put = function(columns, values, callback){
 			body.Row.push(bodyRow);
 		}
 	}
-	this.client.connection.put(utils.url.encode(key), body, function( error, data ){
+	var url = utils.url.build(path, cols);
+	this.client.connection.put(url, body, function( error, data ){
 		if(!callback) return;
 		callback.apply(
 			self

--- a/lib/hbase-utils.js
+++ b/lib/hbase-utils.js
@@ -1,5 +1,6 @@
 
 var crypto = require('crypto');
+var url = require('url');
 
 var utils = {
 	base64: {
@@ -11,36 +12,24 @@ var utils = {
 		}
 	},
 	url: {
-		regexp: /^\/([^\/]+)(\/?([^\/]+))?(\/?([^\/\?]+))?(\/?([\d]+,?[\d]+[^\/\?]))?(\??([^\/]+))?/,
-		encode: function(path){
-			var newpath = '';
-			this.regexp.exec(path)
-			.filter(function(path,i,a){
-				return i%2===1;
-			})
-			.map(function(path,i,a){
-				if(!path) return;
-				if(i===2){
-					var columns = path.split(',');
-					columns.forEach(function(column,i){
-						var colonPosition = column.indexOf(':');
-						if(colonPosition!==-1){
-							newpath += (i===0?'/':',')+encodeURIComponent(column.substr(0,colonPosition));
-							newpath += ':'+encodeURIComponent(column.substr(colonPosition+1));
-						}else{
-							newpath += (i===0?'/':',')+encodeURIComponent(column);
-						}
-					})
-				}else if(i===3){
-					newpath += '/'+path;
-				}else if(i===a.length-1){
-					newpath += '?'+path;
-				}else{
-					newpath += '/'+encodeURIComponent(path);
-				}
-				return path;
-			});
-			return newpath;
+		build: function(path, columns, range, parameters) {
+			path.unshift('') // leading slash
+			path = path.map(encodeURIComponent)
+			if (columns) {
+				if (typeof columns === "string") columns = [columns];
+				var c = columns.map(function(col){
+					return col.split(':').map(encodeURIComponent).join(':')
+				});
+				path.push(c.join(','));
+			}
+			if (range) {
+				var r = '';
+				if (range[0] != null) r += encodeURIComponent(range[0]);
+				if (range[1] != null) r += (',' + encodeURIComponent(range[1]));
+				path.push(r);
+			}
+			parameters = parameters||{}
+			return url.format({pathname: path.join('/'), query: parameters});
 		}
 	},
 	merge: function(obj1,obj2){

--- a/test/testUtils.js
+++ b/test/testUtils.js
@@ -2,30 +2,13 @@
 var utils = require('hbase').utils,
 	assert = require('assert');
 
-exports['URL encode regexp'] = function(){
-	var split = function(path){
-		path = utils.url.regexp.exec(path).filter(function(path,i){
-			return path&&i%2===1;
-		})
-		return path;
-	}
-	assert.deepEqual(['table'],split('/table'));
-	assert.deepEqual(['table'],split('/table/'));
-	assert.deepEqual(['table','key'],split('/table/key'));
-	assert.deepEqual(['table','key'],split('/table/key/'));
-	assert.deepEqual(['table','key','column_family'],split('/table/key/column_family'));
-	assert.deepEqual(['table','key','column_family:colum'],split('/table/key/column_family:colum'));
-	assert.deepEqual(['table','key','column_family:colum'],split('/table/key/column_family:colum/'));
-	assert.deepEqual(['table','key','column_family:colum:test'],split('/table/key/column_family:colum:test/'));
-	assert.deepEqual(['table','key','column_family:colum:test','key=value'],split('/table/key/column_family:colum:test?key=value'));
-	assert.deepEqual(['table','key','column_family:colum','1285941387939'],split('/table/key/column_family:colum/1285941387939'));
-	assert.deepEqual(['table','key','cf1:c1,cf2:c2','1285941387939'],split('/table/key/cf1:c1,cf2:c2/1285941387939'));
-	assert.deepEqual(['table','key','cf1:c1,cf2:c2','1285941387939,1285942722246'],split('/table/key/cf1:c1,cf2:c2/1285941387939,1285942722246'));
-	assert.deepEqual(['table','key','column_family:colum','1285941387939','key=value'],split('/table/key/column_family:colum/1285941387939?key=value'));
-};
-
-exports['URL encode'] = function(){
-	assert.strictEqual('/table/key/%C3%A91:%C3%A81,%C3%A92:%C3%A82/1285941387939?key=value',utils.url.encode('/table/key/é1:è1,é2:è2/1285941387939?key=value'));
-	assert.strictEqual('/table/key/cf:c/1285941387939,1285941387939?key=value',utils.url.encode('/table/key/cf:c/1285941387939,1285941387939?key=value'));
-	assert.strictEqual('/table/key/cf:c?key=value',utils.url.encode('/table/key/cf:c?key=value'));
+exports['URL build'] = function(){
+	assert.strictEqual('/table/key/%C3%A91:%C3%A81,%C3%A92:%C3%A82/1285941387939?key=value',utils.url.build(['table','key'],['é1:è1','é2:è2'],[1285941387939],{key: 'value'}));
+	assert.strictEqual('/table/key/cf:c/1285941387939,1285941387939?key=value',utils.url.build(['table','key'],['cf:c'],[1285941387939,1285941387939],{key: 'value'}));
+	assert.strictEqual('/table/key/cf:c?key=value',utils.url.build(['table','key'],['cf:c'],null,{key: 'value'}));
+	assert.strictEqual('/table/key/cf:c?key=value',utils.url.build(['table','key'],'cf:c',null,{key: 'value'}));
+	assert.strictEqual('/table/key%2Fcontaining%2Fslashes/cf:c?key=value',utils.url.build(['table','key/containing/slashes'],'cf:c',null,{key: 'value'}));
+	assert.strictEqual('/table/key',utils.url.build(['table','key'],null,null,{}));
+	assert.strictEqual('/table/key',utils.url.build(['table','key']));
+	assert.strictEqual('/table/key/c%2Ff:c,cf2,cf3',utils.url.build(['table','key'],['c/f:c','cf2','cf3']));
 };


### PR DESCRIPTION
Thanks for creating the node-hbase client.
After some trouble with row keys containing slashes, I decided to fix the URL creation. All tests pass on my patch, and I added some tests for the new URL encoding.

Regardless of whether you accept the patch: please publish the latest version to npm -- it still only has 0.0.7, which does not work with my node 0.4.2

best, Michael
