### PR TITLE
Use http.request instead of old createClient

### DIFF
--- a/lib/hbase-connection.js
+++ b/lib/hbase-connection.js
@@ -1,131 +1,63 @@
 
 var http = require('http');
 
-function createRequest(method,options, command, callback){
-    var client = http.createClient(options.port,options.host);
-    var request = client.request(method, command, {
-        host: options.host,
-        'content-type':'application/json',
-        'Accept': 'application/json'
-    });
-    // After node v0.3.4 or something, socket is no longer accessible
-    if( request.socket && request.socket.setTimeout ){
-        request.socket.setTimeout(options.timeout);
-        request.socket.addListener("timeout", function() {
-            request.socket.destroy();
-            var e = new Error('408: Client Request Timeout');
-            e.code = 408;
-            e.body = 'Client Request Timeout';
-            callback(e);
-        });
-    }
-    return request;
-}
-
 var Connection = function(client){
     this.client = client;
 };
 
-Connection.prototype.get = function(command,callback){
+Connection.prototype.makeRequest = function(method, command, data, callback) {
     var self = this;
-    var request = createRequest('GET', this.client.options, command, callback);
-    request.end();
-    request.on('response',function(response){
-        var body = '';
-        response.on('data', function(chunk) {
+	var options = {
+    		port: this.client.options.port,
+    		host: this.client.options.host,
+    		method: method,
+    		path: command,
+    		headers: {
+    			'content-type':'application/json',
+    	        'Accept': 'application/json' 
+    	    }
+    };
+    var req = http.request(options, function(res) {
+    	var body = '';
+    	res.on('data', function(chunk) {
             body += chunk;
         });
-        response.on('end', function() {
+        res.on('end', function() {
             var error = null;
             try{
-                body = self.handleJson(response,body);
+                body = self.handleJson(res,body);
             }catch(e){
                 body = null;
                 error = e;
             }
-            callback(error, body, response);
+            callback(error, body, res);
         });
-        response.on('error', function(error) {
-            callback(error,null);
+        res.on('close', function() {
+        	var e = new Error('Connectino closed');
+            callback(e,null);
         });
     });
+    if (data && data != '') {
+    	data = typeof data === 'string' ? data : JSON.stringify(data);
+    	req.write(data, 'utf8');
+    }
+    req.end();
+};
+
+Connection.prototype.get = function(command,callback){
+    this.makeRequest('GET', command, '', callback);
 };
 
 Connection.prototype.put = function(command,data,callback){
-    var self = this;
-    var request = createRequest('PUT', this.client.options, command);
-    data = typeof data === 'string' ? data : JSON.stringify(data);
-    request.end(data, 'utf8');
-    request.on('response',function(response){
-        var body = '';
-        response.on('data', function(chunk) {
-            body += chunk;
-        });
-        response.on('end', function() {
-            var error = null;
-            try{
-                body = self.handleJson(response, body);
-            }catch(e){
-                body = null;
-                error = e;
-            }
-            callback(error, body, response);
-        });
-        response.on('error', function(error) {
-            callback(error);
-        });
-    });
+	this.makeRequest('PUT', command, data, callback);
 };
 
 Connection.prototype.post = function(command,data,callback){
-    var self = this;
-    var request = createRequest('POST', this.client.options, command);
-    data = typeof data === 'string' ? data : JSON.stringify(data);
-    request.end(data, 'utf8');
-    request.on('response',function(response){
-        var body = '';
-        response.on('data', function(chunk) {
-            body += chunk;
-        });
-        response.on('end', function() {
-            var error = null;
-            try{
-                body = self.handleJson(response, body);
-            }catch(e){
-                body = null;
-                error = e;
-            }
-            callback(error, body, response);
-        });
-        response.on('error', function(error) {
-            callback(error,null);
-        });
-    });
+	this.makeRequest('POST', command, data, callback);
 };
 
 Connection.prototype.delete = function(command,callback){
-    var self = this;
-    var request = createRequest('DELETE', this.client.options, command);
-    request.end();
-    request.on('response',function(response){
-        var body = '';
-        response.on('data', function(chunk) {
-            body += chunk;
-        });
-        response.on('end', function() {
-            var error = null;
-            try{
-                body = self.handleJson(response, body);
-            }catch(e){
-                body = null;
-                error = e;
-            }
-            callback(error, body, response);
-        });
-        response.on('error', function(error) {
-            callback(error,null);
-        });
-    });
+    this.makeRequest('DELETE', command, '', callback);
 };
 
 Connection.prototype.handleJson = function(response,body){


### PR DESCRIPTION
This is related to an issue reported by me. I've implemented the usage of http.request. The main problem with the old functionality is that it will open unlimted connections to HBase. The new http implementation uses Agent to throttle the number of concurrent connections, adjustable by agent.maxSockets if needed. 

Also, I have noticed that most of the code in hbase-connection.js is redundant, so I cleaned it up a bit. I am running this patched version myself in pre-production, but review is appreciated.
