### PR TITLE
Add links to homepage, git and bugs.

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,4 +15,12 @@
     }],
     "main": "./lib/hbase",
     "engines": { "node": ">= 0.1.90" }
+    "bugs": {
+        "url": "https://github.com/wdavidw/node-hbase/issues"
+    },
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/wdavidw/node-hbase.git"
+    },
+    "homepage": "https://github.com/wdavidw/node-hbase",
 }


### PR DESCRIPTION
Add links to the github page from `package.json`, so the homepage, bugs and git-stuff is discoverable through `npm info hbase`.
