### PR TITLE
Support SingleColumnValueFilter and StringComparator

### DIFF
--- a/lib/hbase-scanner.js
+++ b/lib/hbase-scanner.js
@@ -37,10 +37,25 @@ Scanner.prototype.create = function(params,callback){
         }
     }
     if(params.filter){
+        var fieldsToEncode = {
+            value: { // generic, used for many filters
+                exceptions: {
+                    RegexStringComparator: true,
+                    PageFilter: true,
+                    SubstringComparator: true
+                }
+            }, 
+            family: {}, // SingleColumnValueFilter to specify what column to search
+            qualifier: {}, // SingleColumnValueFilter to specify what column to search
+        };
         var encode = function(obj){
             for(var k in obj){
-                if(k === 'value' && (!obj['type'] || obj['type'] !== 'RegexStringComparator' && obj['type'] !== 'PageFilter')){
-                    obj[k] = utils.base64.encode(obj[k]);
+                var field = fieldsToEncode[k];
+                if(field) {
+                    var exceptions = field.exceptions;
+                    if (!exceptions || !obj['type'] || !exceptions[obj['type']]) {
+                        obj[k] = utils.base64.encode(obj[k]);
+                    }
                 }else if(typeof obj[k] === 'object'){
                     encode(obj[k]);
                 }

--- a/test/testFilter.coffee
+++ b/test/testFilter.coffee
@@ -161,3 +161,21 @@ module.exports =
                     assert.strictEqual('test_filter|row_2', cells[0].key)
                     assert.strictEqual('node_column_family:bb', cells[0].column)
                     this.delete next
+    'SingleColumnValueFilter # op equal substringcomparator': (next) ->
+        utils.getClient (error, client) ->
+            client
+            .getScanner('node_table')
+            .create
+                startRow: 'test_filter|row_1'
+                endRow: 'test_filter|row_4'
+                maxVersions: 1
+                filter: {"family":"node_column_family","qualifier":"aa","op":"EQUAL","type":"SingleColumnValueFilter","comparator":{"value":"ab","type":"SubstringComparator"}}
+            , (error,id) ->
+                assert.ifError error
+                this.get (error,cells) ->
+                    assert.ifError error
+                    assert.strictEqual(3,cells.length)
+                    assert.strictEqual('test_filter|row_1', cells[0].key)
+                    assert.strictEqual('test_filter|row_1', cells[1].key)
+                    assert.strictEqual('test_filter|row_1', cells[2].key)
+                    this.delete next


### PR DESCRIPTION
changed the way filters are encoded to match the REST API.  this does not bring it into 100% compatibility and I've only tested these 2 new classes.
