### PR TITLE
add kdestroy function

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,34 @@ hbase({
 .version();
 ```
 
+Using kdestroy:
+```javascript
+const hbase = require('hbase');
+const client = hbase({
+  host: '127.0.0.1',
+  port: 8080,
+  "krb5": {
+    "principal": "{username}@{REALM}",
+    "password": "{password}",
+    "service_principal": "HTTP@{fqdn}"
+  }
+});
+
+/**
+ * destroys credential cache
+ * options: 
+ *  ccname (optionnal) 
+ *    Credential cache location. If this is not specified, default path is taken from environment variable KRB5CCNAME, then from /etc/krb5.conf.
+ * callback
+ *  err
+ *    Should be undefined. Otherwise it contains an error message.
+ * eg:
+ *  1. no options ->  client.kdestroy(callback)
+ *  2. nothing -> client.kdestroy()
+ */
+client.kdestroy(options, callback)
+```
+
 ## Scanner and Filters
 
 The scanner implement the `stream.Readable` API. For ease of usage, an optional

--- a/lib/client.js
+++ b/lib/client.js
@@ -17,7 +17,7 @@ Row = require("./row");
 Scanner = require("./scanner");
 
 // ## Constructor
-Client = function(options) {
+Client = function (options) {
   var ref;
   if (!options) {
     options = {};
@@ -51,29 +51,29 @@ util.inherits(Client, EventEmitter);
 // ## `client.version`
 
 // Query Software Version.
-Client.prototype.version = function(callback) {
+Client.prototype.version = function (callback) {
   return this.connection.get("/version", callback);
 };
 
 // ## `client.version_cluster`
 
 // Query Storage Cluster Version.
-Client.prototype.version_cluster = function(callback) {
+Client.prototype.version_cluster = function (callback) {
   return this.connection.get("/version/cluster", callback);
 };
 
 // ## `client.status_cluster`
 
 // Query Storage Cluster Status.
-Client.prototype.status_cluster = function(callback) {
+Client.prototype.status_cluster = function (callback) {
   return this.connection.get("/status/cluster", callback);
 };
 
 // ## `client.tables`
 
 // List tables.
-Client.prototype.tables = function(callback) {
-  return this.connection.get("/", function(err, data) {
+Client.prototype.tables = function (callback) {
+  return this.connection.get("/", function (err, data) {
     return callback(err, (data && data.table ? data.table : null));
   });
 };
@@ -81,8 +81,24 @@ Client.prototype.tables = function(callback) {
 // ## `client.table`
 
 // Return a new instance of "hbase.Table".
-Client.prototype.table = function(name) {
+Client.prototype.table = function (name) {
   return new Table(this, name);
 };
+
+/**
+ * destroys credential cache
+ * options: 
+ *  ccname (optionnal) 
+ *    Credential cache location. If this is not specified, default path is taken from environment variable KRB5CCNAME, then from /etc/krb5.conf.
+ * callback
+ *  err
+ *    Should be undefined. Otherwise it contains an error message.
+ * eg:
+ *  1. no options ->  kdestroy(callback)
+ *  2. nothing -> kdestroy()
+ */
+Client.prototype.kdestroy = function (options, callback) {
+  return this.connection.kdestroy(options, callback);
+}
 
 module.exports = Client;

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -29,7 +29,7 @@ try {
 // ## Utilities
 
 // Based on https://coffeescript-cookbook.github.io/chapters/classes_and_objects/cloning
-clone = function(obj) {
+clone = function (obj) {
   var key, newInstance;
   if ((obj == null) || typeof obj !== 'object') {
     return obj;
@@ -41,12 +41,12 @@ clone = function(obj) {
   return newInstance;
 };
 
-is_object = function(obj) {
+is_object = function (obj) {
   return (obj != null) && typeof obj === 'object';
 };
 
 // ## Constructor
-Connection = function(client) {
+Connection = function (client) {
   var options;
   this.client = client;
   options = clone(this.client.options);
@@ -61,7 +61,7 @@ Connection = function(client) {
   return this;
 };
 
-Connection.prototype.makeRequest = function(method, command, data, callback) {
+Connection.prototype.makeRequest = function (method, command, data, callback) {
   var do_async, do_krb5, do_request, do_spnego, do_token, options;
   options = clone(this.options);
   options.method = method;
@@ -91,7 +91,7 @@ Connection.prototype.makeRequest = function(method, command, data, callback) {
       return do_token();
     }
     // Kinit first if password or keytab provided
-    return krb5.kinit(this.client.options.krb5, function(err, ccname) {
+    return krb5.kinit(this.client.options.krb5, function (err, ccname) {
       if (err) {
         return callback(Error(err));
       }
@@ -99,7 +99,7 @@ Connection.prototype.makeRequest = function(method, command, data, callback) {
     });
   };
   do_token = () => {
-    return krb5.spnego(this.client.options.krb5, function(err, token) {
+    return krb5.spnego(this.client.options.krb5, function (err, token) {
       var e;
       e = 'GSS error ' + err;
       if (err) {
@@ -118,7 +118,7 @@ Connection.prototype.makeRequest = function(method, command, data, callback) {
     req = http[this.client.options.protocol].request(options, (res) => {
       var body;
       body = '';
-      res.on('data', function(chunk) {
+      res.on('data', function (chunk) {
         return body += chunk;
       });
       res.on('end', () => {
@@ -133,11 +133,11 @@ Connection.prototype.makeRequest = function(method, command, data, callback) {
         }
         return callback(error, body, res);
       });
-      return res.on('error', function(err) {
+      return res.on('error', function (err) {
         return callback(err);
       });
     });
-    req.on('error', function(err) {
+    req.on('error', function (err) {
       return callback(err);
     });
     if (data && data !== '') {
@@ -146,7 +146,7 @@ Connection.prototype.makeRequest = function(method, command, data, callback) {
     }
     // Handle Timeout
     if (options.timeout) {
-      req.setTimeout(options.timeout, function() {
+      req.setTimeout(options.timeout, function () {
         return req.abort();
       });
     }
@@ -156,23 +156,23 @@ Connection.prototype.makeRequest = function(method, command, data, callback) {
   return do_async();
 };
 
-Connection.prototype.get = function(command, callback) {
+Connection.prototype.get = function (command, callback) {
   return this.makeRequest('GET', command, '', callback);
 };
 
-Connection.prototype.put = function(command, data, callback) {
+Connection.prototype.put = function (command, data, callback) {
   return this.makeRequest('PUT', command, data, callback);
 };
 
-Connection.prototype.post = function(command, data, callback) {
+Connection.prototype.post = function (command, data, callback) {
   return this.makeRequest('POST', command, data, callback);
 };
 
-Connection.prototype.delete = function(command, callback) {
+Connection.prototype.delete = function (command, callback) {
   return this.makeRequest('DELETE', command, '', callback);
 };
 
-Connection.prototype.handleJson = function(response, body) {
+Connection.prototype.handleJson = function (response, body) {
   var e;
   switch (response.statusCode) {
     // Created
@@ -247,5 +247,9 @@ Connection.prototype.codes = {
   509: 'Bandwidth Limit Exceeded (Apache bw/limited extension)',
   510: 'Not Extended'
 };
+
+Connection.prototype.kdestroy = function (options, callback) {
+  return krb5.kdestroy(options, callback)
+}
 
 module.exports = Connection;


### PR DESCRIPTION
when I used krb5,  after sending every request,  it will create one record of klist. it will throw error when kerbos`s cache is full. so I add this function.